### PR TITLE
Use *ns* as the default namespace for superclasses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+target/
+.lein*
+.nrepl*
+*~

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ Examples
 	(defclass fShape [] []
 	  (get area -1)
 	  (get perimeter -1))
-	
-	(defclass fSquare [user/fShape] [side]
+
+	(defclass fSquare [fShape] [side]
 	  (get area (* side side))
 	  (get perimeter (* side 4)))
-	
-	(defclass fCircle [user/fShape] [radius]
+
+	(defclass fCircle [fShape] [radius]
 	  (get diameter (* radius 2))
 	  (get area (* Math/PI (* radius radius)))
 	  (get perimeter (* Math/PI (get-slot *self* :diameter))))
@@ -78,9 +78,9 @@ Another example will help illustrate more features of Fenrir:
 
 	(defclass fPet [] [name age owner]
 	  "A pet of any kind."
-	  (make-noise "Make some pet noise."))
+	  (make-noise [] "Make some pet noise."))
 
-	(defclass fDog [fenrir/fPet] []
+	(defclass fDog [fPet] []
 	  "A dog of any race."
 	  (set age (if (< *val* 15) *val* -1)) ; If the dog is too old, put it to sleep...
 	  (get name (str owner "'s dog, " name))
@@ -91,12 +91,12 @@ Another example will help illustrate more features of Fenrir:
 	  (get name (str name ", Copyright (C) " manufacturer " 2011"))
 	  (explode [] (println "BOOM!")))
 
-	(defclass fRoboDog [fenrir/fDog fenrir/fMachine] [name]
+	(defclass fRoboDog [fDog fMachine] [name]
 	  "fDog 2.0"
 	  (ctor [name age owner manufacturer]
 	    (base-ctor *fclass* :name name :age age :owner owner :manufacturer manufacturer))
 	  (make-noise [] (println "*Buzz* Bark! *Buzz*"))
-	  (mask name fenrir/fMachine))
+	  (mask name fMachine))
 
 Before explaining everything, try this:
 

--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,11 @@
-(defproject fenrir "0.1.0"
+(defproject fenrir "0.1.1"
   :description "An alternative class-based object-system for Clojure based on hash-maps and multimethods."
   :url "https://github.com/eduardoejp/fenrir"
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo
             :comments "same as Clojure"}
-  :dependencies [[org.clojure/clojure "1.2.0"]
-                 [org.clojure/clojure-contrib "1.2.0"]]
+  :dependencies [[org.clojure/clojure "1.6.0"]]
   :dev-dependencies [[org.clojars.rayne/autodoc "0.8.0-SNAPSHOT"]]
   :autodoc {:name "fenrir"
             :description "An alternative class-based object-system for Clojure based on hash-maps and multimethods."
@@ -14,4 +13,5 @@
             :web-src-dir "http://github.com/eduardoejp/fenrir/blob/"
             :web-home "http://eduardoejp.github.com/fenrir/"
             :output-path "autodoc"}
+  :main fenrir
 	)

--- a/src/fenrir.clj
+++ b/src/fenrir.clj
@@ -1,6 +1,6 @@
 ;; Copyright (C) 2011, Eduardo Julián. All rights reserved.
 ;;
-;; The use and distribution terms for this software are covered by the 
+;; The use and distribution terms for this software are covered by the
 ;; Eclipse Public License 1.0
 ;; (http://opensource.org/licenses/eclipse-1.0.php) which can be found
 ;; in the file epl-v10.html at the root of this distribution.
@@ -84,7 +84,9 @@
 (defmacro defclass
   "Creates an fClass meta-object for creating fobjects."
   [sym supers slots & meths]
-  (let [; Extract the doc-string
+  (let [; Namespace any un-namespaced supers to *ns*
+        supers (map #(if (namespace %) % (add-ns %)) supers)
+        ; Extract the doc-string
         doc-str (when (string? (first meths)) (first meths))
         meths (if (string? (first meths)) (rest meths) meths)
         ; Complete the set of slots for the meta-object.

--- a/test/fenrir/core_test.clj
+++ b/test/fenrir/core_test.clj
@@ -1,0 +1,106 @@
+(ns fenrir.core-test
+  (:require [clojure.test :refer :all]
+            [fenrir :refer :all]))
+
+;;;
+
+(defclass fShape [] []
+  (get area -1)
+  (get perimeter -1))
+
+(defclass fSquare [fShape] [side]
+  (get area (* side side))
+  (get perimeter (* side 4)))
+
+(defclass fCircle [fShape] [radius]
+  (get diameter (* radius 2))
+  (get area (* Math/PI (* radius radius)))
+  (get perimeter (* Math/PI (get-slot *self* :diameter))))
+
+(def s (ctor fShape))
+(def sq (ctor fSquare :side 5))
+(def cir (ctor fCircle :radius 6))
+
+(deftest shape-tests
+  (testing "shape"
+    (are [x] (= x -1)
+      (get-slot s :area)
+      (get-slot s :perimeter)))
+  (testing "square"
+    (is (= 5 (get-slot sq :side)))
+    (is (= 25 (get-slot sq :area)))
+    (is (= 20 (get-slot sq :perimeter))))
+  (testing "circle"
+    (is (= 6 (get-slot cir :radius)))
+    (is (= 12 (get-slot cir :diameter)))
+    (is (= (* Math/PI 36) (get-slot cir :area)))
+    (is (= (* Math/PI 12) (get-slot cir :perimeter)))))
+
+;;;
+
+(defclass fPet [] [name age owner]
+  "A pet of any kind."
+  (make-noise [] "Make some pet noise."))
+
+(defclass fDog [fPet] []
+  "A dog of any race."
+  (set age (if (< *val* 15) *val* -1)) ; If the dog is too old, put it to sleep...
+  (get name (str owner "'s dog, " name))
+  (make-noise [] (println "Bark!")))
+
+(defclass fMachine [] [name manufacturer]
+  "A machine of some kind."
+  (get name (str name ", Copyright (C) " manufacturer " 2015"))
+  (explode [] (println "BOOM!")))
+
+(defclass fRoboDog [fDog fMachine] [name]
+  "fDog 2.0"
+  (ctor [name age owner manufacturer]
+    (base-ctor *fclass* :name name :age age :owner owner :manufacturer manufacturer))
+  (make-noise [] (println "*Buzz* Bark! *Buzz*"))
+  (mask name fMachine))
+
+(def pet (ctor fPet :name "Claws" :age 5 :owner "Mr. Foo"))
+(def dog (ctor fDog :name "Rex" :age 5 :owner "Mr. Bar"))
+(def machine (ctor fMachine :name "IPhone" :manufacturer "Apple Inc."))
+(def robodog (ctor fRoboDog "TRex" 10 "Ms. Baz" "Bots R Us"))
+
+(deftest robopet-tests
+  (testing "pet"
+    (is (= "Make some pet noise." (make-noise pet))))
+  (testing "dog"
+    (is (= "Bark!\n" (with-out-str (make-noise dog))))
+    (is (= "Mr. Bar's dog, Rex" (get-slot dog :name)))
+    (let [pup (set-slot dog :age 3)]
+      (is (= 3 (get-slot pup :age))))
+    (let [too-old (set-slot dog :age 18)]
+      (is (= -1 (get-slot too-old :age)))))
+  (testing "machine"
+    (is (= "Apple Inc." (get-slot machine :manufacturer)))
+    (is (= "IPhone, Copyright (C) Apple Inc. 2015" (get-slot machine :name))))
+  (testing "robodog"
+    (is (= "*Buzz* Bark! *Buzz*\n" (with-out-str (make-noise robodog))))
+    (is (= "TRex, Copyright (C) Bots R Us 2015" (get-slot robodog :name)))))
+
+;;;
+
+(ns chess
+  (:require [fenrir :refer :all]))
+
+(defclass Piece [] [rank]
+  (pawn? "Returns whether or not this piece is a pawn."))
+
+(in-ns 'fenrir.core-test)
+
+(defclass Color [] [color]
+  (get color (str "the color " color)))
+
+(defclass Knight [chess/Piece Color] []
+  (pawn? [] false))
+
+(def knight (ctor Knight :color "black"))
+
+(deftest namespace-tests
+  (testing "a class inheriting from a class in another namespace"
+    (is (= false (pawn? knight)))
+    (is (= "the color black" (get-slot knight :color)))))


### PR DESCRIPTION
Great work on Fenrir! I'm finding it super useful for OOP-oriented things involving class hierarchies.

I made this little tweak that allows you to omit the namespace for superclasses that are in the same namespace. So for example, if you're defining everything in the same namespace, you can do, e.g.:

```
(defclass Pet [] [name age owner]
  ...)

(defclass Dog [Pet] []
  ...)
```

without having to namespace Pet. Of course, you can still supply namespace names like before.

Let me know what you think!
